### PR TITLE
A demo to test the deleting conversation function

### DIFF
--- a/QuickStart/LQSViewController.m
+++ b/QuickStart/LQSViewController.m
@@ -518,6 +518,7 @@ static UIColor *LSRandomColor(void)
 - (void)didReceiveLayerObjectsDidChangeNotification:(NSNotification *)notification;
 {
     // Get nav bar colors from conversation metadata
+     NSLog(@"The conversation's meta data is:%@",self.conversation.metadata);
     [self setNavbarColorFromConversationMetadata:self.conversation.metadata];
     [self fetchLayerConversation];
 }
@@ -598,30 +599,31 @@ static UIColor *LSRandomColor(void)
 {
     
     
-    LYRQuery *message = [LYRQuery queryWithQueryableClass:[LYRMessage class]];
+    // LYRQuery *message = [LYRQuery queryWithQueryableClass:[LYRMessage class]];
     
-    NSError *error;
-    NSOrderedSet *messageList = [self.layerClient executeQuery:message error:&error];
+    // NSError *error;
+    // NSOrderedSet *messageList = [self.layerClient executeQuery:message error:&error];
     
     
     
-    if ([messageList count] > 0)
-    {
+    // if ([messageList count] > 0)
+    // {
         
-        for (int i = 0; i < [messageList count];  i++)
-        {
-            LYRMessage *message = [messageList objectAtIndex:i];
-            bool success = [message delete:LYRDeletionModeAllParticipants error:&error];
-            NSLog(@"Message is: %@", message.parts);
+    //     for (int i = 0; i < [messageList count];  i++)
+    //     {
+    //         LYRMessage *message = [messageList objectAtIndex:i];
+    //         bool success = [message delete:LYRDeletionModeAllParticipants error:&error];
+    //         NSLog(@"Message is: %@", message.parts);
             
-            if (success) {
-                NSLog(@"The message has been delted");
-            }else {
-                NSLog(@"Error");
-            }
-        }
+    //         if (success) {
+    //             NSLog(@"The message has been delted");
+    //         }else {
+    //             NSLog(@"Error");
+    //         }
+    //     }
         
-    }
+    // }
+    [self.conversation delete:LYRDeletionModeLocal error:nil];
 }
 
 - (IBAction)CameraButtonPressed:(UIButton *)sender {


### PR DESCRIPTION
Hi All,

I think I found a issue about deleting the conversation local, could you run the demo to check it? Thanks.

You can do this as the following step after you install the app on your device and simulator:
1, Shake your device so that the conversation has a colour meta data.
2, Send a message from Device to Simulator, You will find the meta data is existing on the Simulator side.
3, Click the clear button on the Simulator side.
4, Send a message from Device to Simulator again, you will see the meta data is gone on the Simulator side, but it is existing on the device side.

This a same conversation between the Simulator and Device. I think it is a bug.

Could you check it? Thanks.
